### PR TITLE
Three small changes (version 1.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
     ```sh
     cd path-to-qb-schema/
-    yarn && yarn develop
+    yarn && yarn dev
     ```
 
 1.  **Open the source code and start editing!**

--- a/schema.graphql
+++ b/schema.graphql
@@ -372,12 +372,12 @@ type Match {
   id: ID!
 
   """
-  The number of tossups read, *including* any tossups read in overtime.
+  The number of tossups read, *including* any tossups read in overtime. This should be absent or null (not `0`) in forfeit matches.
   """
   tossups_read: Int
 
   """
-  The number of tossups read in overtime.
+  The number of tossups read in overtime. This should be absent or null (not `0`) in forfeit matches.
   """
   overtime_tossups_read: Int
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -758,7 +758,7 @@ type Player {
   name: String!
 
   """
-  The player's year in school. Use `0` for kindergarten, `1` for first grade, &hellip;, `12` for twelfth grade (senior in high school), `13` for college frosh, &hellip;, `16` for college senior, `17` for college post-senior, and `18` for graduate student.
+  The player's year in school. Use `0` for kindergarten, `1` for first grade, &hellip;, `12` for twelfth grade (senior in high school), `13` for college frosh, &hellip;, `16` for college senior, `17` for college post-senior, and `18` for graduate student. Use `-1` when the notion of a grade is known to be inapplicable, e.g., for players who are not enrolled in school (this is distinct from omitting the field, which implies the player's year is unknown).
   """
   year: Int
 }

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -4,7 +4,7 @@ title: Introduction
 
 Here we present an object schema for describing a quizbowl tournament. Note that this is about the necessary data to pass back and forth and get a full recounting of what happened; it does not attempt to be any type of database schema.
 
-## Current version: **1.4.1**
+## Current version: **1.5**
 
 Your feedback on the schema is welcome—it's [open source](http://github.com/quizbowl/schema)!
 

--- a/src/pages/serialization.md
+++ b/src/pages/serialization.md
@@ -10,7 +10,7 @@ All of the data types in the schema for an object are either native JSON data ty
 
 Indeed, native JSON data types serialize as you would expect in JSON; object types defined here serialize as JSON objects with a few extra fields.
 
-The top level of the JSON file **must** be an object with keys for `version` (the current version is `1.4.1`), and `objects`, an array of objects; among these objects, there should be exactly one object of type `Tournament` and any number of other objects.
+The top level of the JSON file **must** be an object with keys for `version` (the current version is `1.5`), and `objects`, an array of objects; among these objects, there should be exactly one object of type `Tournament` and any number of other objects.
 
 The file's extension should be `.qbj` and its MIME type should be `application/vnd.quizbowl.qbj+json`.
 


### PR DESCRIPTION
* Specify that `tossups_read` and `overtime_tossups_read` should be absent in forfeits
* Allow `Player.year` to be `-1`, indicating that the notion of a year in school is inapplicable to the player (distinct from `null`, which indicates unknown year)
* Correct the `yarn` command (`dev`, not `develop`)